### PR TITLE
Development

### DIFF
--- a/Plotting/plot_functions.py
+++ b/Plotting/plot_functions.py
@@ -8,10 +8,7 @@ def test_for_zero(num):
     :param num: <numpy.ndarray>
     :return mask: <numpy.ndarray> A boolean-type mask, 1 for valid, 0 for ignore
     """
-    # mask = np.zeros_like(num, dtype=np.bool)
-
     num[num == 0.0] = 0.001
-    # mask[num != 0.0] = True
 
     return num
 
@@ -36,13 +33,10 @@ def msavi(R, NIR):
     :return:
     """
     sqrt = (2.0 * (NIR * 0.0001) + 1.0) ** 2.0 - 8.0 * ((NIR * 0.0001) - (R * 0.0001))
+
     sqrt = test_for_negative(sqrt)
 
     result = (2.0 * (NIR * 0.0001) + 1.0 - (sqrt ** 0.5)) / 2.0
-
-    # result[result >= 1.0] = 1.0
-
-    # result[result <= -1.0] = -1.0
 
     return result
 
@@ -59,15 +53,7 @@ def ndvi(R, NIR):
 
     den = test_for_zero(den)
 
-    # result = np.zeros_like(R, dtype=np.float32)
-
-    # result[mask] = (NIR[mask] - R[mask]) / (NIR[mask] + R[mask])
-
     result = (NIR - R) / den
-
-    # result[result >= 1.0] = 1.0
-
-    # result[result <= -1.0] = -1.0
 
     return result
 
@@ -86,13 +72,10 @@ def evi(B, R, NIR, G=2.5, L=1.0, C1=6.0, C2=7.5):
     :return:
     """
     den = (NIR * 0.0001) + C1 * (R * 0.0001) - C2 * (B * 0.0001) + L
+
     den = test_for_zero(den)
 
-    # result[mask] = G * ((NIR[mask] - R[mask]) / (NIR[mask] + C1 * R[mask] - C2 * B[mask] + L))
     result = G * (((NIR * 0.0001) - (R * 0.0001)) / den)
-
-    # result[result >= 5] = 0
-    # result[result <= -5] = 0
 
     return result
 
@@ -107,10 +90,9 @@ def savi(R, NIR, L=0.5):
     :return:
     """
     den = (NIR * 0.0001) + (R * 0.0001) + L
-    den = test_for_zero(den)
-    # result = np.zeros_like(R, dtype=np.float32)
 
-    # result[mask] = ((NIR[mask] - R[mask]) / (NIR[mask] +R[mask] + L)) * (1 + L)
+    den = test_for_zero(den)
+
     result = (((NIR * 0.0001) - (R * 0.0001)) / den) * (1 + L)
 
     return result
@@ -125,10 +107,9 @@ def ndmi(NIR, SWIR1):
     :return:
     """
     den = NIR + SWIR1
-    den = test_for_zero(den)
-    # result = np.zeros_like(NIR, dtype=np.float32)
 
-    # result[mask] = (NIR[mask] - SWIR1[mask]) / (NIR[mask] + SWIR1[mask])
+    den = test_for_zero(den)
+
     result = (NIR - SWIR1) / den
 
     return result
@@ -143,10 +124,9 @@ def nbr(NIR, SWIR2):
     :return:
     """
     den = NIR + SWIR2
-    den = test_for_zero(den)
-    # result = np.zeros_like(NIR, dtype=np.float32)
 
-    # result[mask] = (NIR[mask] - SWIR2[mask]) / (NIR[mask] + SWIR2[mask])
+    den = test_for_zero(den)
+
     result = (NIR - SWIR2) / den
 
     return result
@@ -161,10 +141,9 @@ def nbr2(SWIR1, SWIR2):
     :return:
     """
     den = SWIR1 + SWIR2
-    den = test_for_zero(den)
-    # result = np.zeros_like(SWIR1, dtype=np.float32)
 
-    # result[mask] = (SWIR1[mask] - SWIR2[mask]) / (SWIR1[mask] + SWIR2[mask])
+    den = test_for_zero(den)
+
     result = (SWIR1 - SWIR2) / den
 
     return result

--- a/Plotting/plot_functions.py
+++ b/Plotting/plot_functions.py
@@ -10,7 +10,7 @@ def test_for_zero(num):
     """
     # mask = np.zeros_like(num, dtype=np.bool)
 
-    num[num == 0] = 0.001
+    num[num == 0.0] = 0.001
     # mask[num != 0.0] = True
 
     return num
@@ -35,13 +35,14 @@ def msavi(R, NIR):
     :param NIR:
     :return:
     """
-    sqrt = test_for_negative((2.0 * NIR + 1.0) ** 2.0 - 8.0 * (NIR - R))
+    sqrt = (2.0 * (NIR * 0.0001) + 1.0) ** 2.0 - 8.0 * ((NIR * 0.0001) - (R * 0.0001))
+    sqrt = test_for_negative(sqrt)
 
-    result = (2.0 * NIR + 1.0 - (sqrt ** 0.5)) / 2.0
+    result = (2.0 * (NIR * 0.0001) + 1.0 - (sqrt ** 0.5)) / 2.0
 
-    result[result >= 1.0] = 1.0
+    # result[result >= 1.0] = 1.0
 
-    result[result <= -1.0] = -1.0
+    # result[result <= -1.0] = -1.0
 
     return result
 
@@ -54,22 +55,24 @@ def ndvi(R, NIR):
     :param NIR:
     :return:
     """
-    res = test_for_zero(NIR + R)
+    den = NIR + R
+
+    den = test_for_zero(den)
 
     # result = np.zeros_like(R, dtype=np.float32)
 
     # result[mask] = (NIR[mask] - R[mask]) / (NIR[mask] + R[mask])
 
-    result = (NIR - R) / res
+    result = (NIR - R) / den
 
-    result[result >= 1.0] = 1.0
+    # result[result >= 1.0] = 1.0
 
-    result[result <= -1.0] = -1.0
+    # result[result <= -1.0] = -1.0
 
     return result
 
 
-def evi(B, R, NIR, G=2.5, L=1.0, C1=6, C2=7.5):
+def evi(B, R, NIR, G=2.5, L=1.0, C1=6.0, C2=7.5):
     """
     Enhanced Vegetation Index
     G * ((NIR - R) / (NIR + C1 * R - C2 * B + L))
@@ -82,14 +85,14 @@ def evi(B, R, NIR, G=2.5, L=1.0, C1=6, C2=7.5):
     :param C2: <float> Constant
     :return:
     """
-    res = test_for_zero(NIR + C1 * R - C2 * B + L)
-    # result = np.zeros_like(R, dtype=np.float32)
+    den = (NIR * 0.0001) + C1 * (R * 0.0001) - C2 * (B * 0.0001) + L
+    den = test_for_zero(den)
 
     # result[mask] = G * ((NIR[mask] - R[mask]) / (NIR[mask] + C1 * R[mask] - C2 * B[mask] + L))
-    result = G * ((NIR - R) / res)
+    result = G * (((NIR * 0.0001) - (R * 0.0001)) / den)
 
-    result[result >= 5] = 0
-    result[result <= -5] = 0
+    # result[result >= 5] = 0
+    # result[result <= -5] = 0
 
     return result
 
@@ -103,11 +106,12 @@ def savi(R, NIR, L=0.5):
     :param L:
     :return:
     """
-    res = test_for_zero(NIR + R + L)
+    den = (NIR * 0.0001) + (R * 0.0001) + L
+    den = test_for_zero(den)
     # result = np.zeros_like(R, dtype=np.float32)
 
     # result[mask] = ((NIR[mask] - R[mask]) / (NIR[mask] +R[mask] + L)) * (1 + L)
-    result = ((NIR - R) / (res)) * (1 + L)
+    result = (((NIR * 0.0001) - (R * 0.0001)) / den) * (1 + L)
 
     return result
 
@@ -120,11 +124,12 @@ def ndmi(NIR, SWIR1):
     :param SWIR1:
     :return:
     """
-    res = test_for_zero(NIR + SWIR1)
+    den = NIR + SWIR1
+    den = test_for_zero(den)
     # result = np.zeros_like(NIR, dtype=np.float32)
 
     # result[mask] = (NIR[mask] - SWIR1[mask]) / (NIR[mask] + SWIR1[mask])
-    result = (NIR - SWIR1) / res
+    result = (NIR - SWIR1) / den
 
     return result
 
@@ -137,11 +142,12 @@ def nbr(NIR, SWIR2):
     :param SWIR2:
     :return:
     """
-    res = test_for_zero(NIR + SWIR2)
+    den = NIR + SWIR2
+    den = test_for_zero(den)
     # result = np.zeros_like(NIR, dtype=np.float32)
 
     # result[mask] = (NIR[mask] - SWIR2[mask]) / (NIR[mask] + SWIR2[mask])
-    result = (NIR - SWIR2) / res
+    result = (NIR - SWIR2) / den
 
     return result
 
@@ -154,10 +160,11 @@ def nbr2(SWIR1, SWIR2):
     :param SWIR2:
     :return:
     """
-    res = test_for_zero(SWIR1 + SWIR2)
+    den = SWIR1 + SWIR2
+    den = test_for_zero(den)
     # result = np.zeros_like(SWIR1, dtype=np.float32)
 
     # result[mask] = (SWIR1[mask] - SWIR2[mask]) / (SWIR1[mask] + SWIR2[mask])
-    result = (SWIR1 - SWIR2) / res
+    result = (SWIR1 - SWIR2) / den
 
     return result

--- a/retrieve_data.py
+++ b/retrieve_data.py
@@ -130,19 +130,20 @@ class CCDReader:
         self.masked_on = masked_on
 
         # Calculate indices from observed values
-        self.EVI = plot_functions.evi(B=self.data[0], NIR=self.data[3], R=self.data[2])
+        self.EVI = plot_functions.evi(B=self.data[0].astype(np.float), NIR=self.data[3].astype(np.float),
+                                      R=self.data[2].astype(np.float))
 
-        self.NDVI = plot_functions.ndvi(R=self.data[2], NIR=self.data[3])
+        self.NDVI = plot_functions.ndvi(R=self.data[2].astype(np.float), NIR=self.data[3].astype(np.float))
 
-        self.MSAVI = plot_functions.msavi(R=self.data[2], NIR=self.data[3])
+        self.MSAVI = plot_functions.msavi(R=self.data[2].astype(np.float), NIR=self.data[3].astype(np.float))
 
-        self.SAVI = plot_functions.savi(R=self.data[2], NIR=self.data[3])
+        self.SAVI = plot_functions.savi(R=self.data[2].astype(np.float), NIR=self.data[3].astype(np.float))
 
-        self.NDMI = plot_functions.ndmi(NIR=self.data[3], SWIR1=self.data[4])
+        self.NDMI = plot_functions.ndmi(NIR=self.data[3].astype(np.float), SWIR1=self.data[4].astype(np.float))
 
-        self.NBR = plot_functions.nbr(NIR=self.data[3], SWIR2=self.data[5])
+        self.NBR = plot_functions.nbr(NIR=self.data[3].astype(np.float), SWIR2=self.data[5].astype(np.float))
 
-        self.NBR2 = plot_functions.nbr2(SWIR1=self.data[4], SWIR2=self.data[5])
+        self.NBR2 = plot_functions.nbr2(SWIR1=self.data[4].astype(np.float), SWIR2=self.data[5].astype(np.float))
 
         # Calculate indices from the results' change models.  The change models are stored by order of model, then
         # band number.  For example, the band values for the first change model are represented by indices 0-5,


### PR DESCRIPTION
Noticed that the band-index calculations were generating wonky results.  Realized a few things:
-Was not explicitly passing floating point values to the calculations
-Was assuming no rescaling was needed for calculations that use hard-coded coefficients

I added .astype(np.float) so that all input arrays into the plot_functions.py calculations will be the correct type.  I multiplied arrays by 0.0001 to get the correct scaling for calculations that use hard-coded coefficients.

I compared the results with the previous calculations and everything looks much better.  Namely, output values are now in the -1 to 1 range, and I'm no longer seeing the divide by 0 warning.  Note that I was testing for 0 in the denominators previously, but it wasn't working properly because I probably had value overflows or something like that happening.  Making sure everything is float seems to have fixed this.